### PR TITLE
update default items per folder page

### DIFF
--- a/src/util/parse.py
+++ b/src/util/parse.py
@@ -56,7 +56,7 @@ def parse_section_page_count(section):
 def parse_folder_page_count(folder):
     folder_pagination = folder.find(class_='pagination')
     folder_total = int(folder_pagination.next_sibling.next_sibling.next_sibling.next_sibling.text)
-    return math.ceil(folder_total / 20)
+    return math.ceil(folder_total / 50)
 
 
 # There are two sections of responsive file attachments visible to user: public and requester.


### PR DESCRIPTION
For me, the NextRequest website currently uses 50 items per folder page instead of 20.

Using 20 works sometimes, but can cause crashes or unnecessary requests when going outside the total page count.